### PR TITLE
Added cancelLabel to Form templates

### DIFF
--- a/Resources/views/_form/horizontal.html.twig
+++ b/Resources/views/_form/horizontal.html.twig
@@ -92,7 +92,7 @@
         <div class="form-group row">
             <div class="col-lg-offset-{{ labelSpan }} col-lg-{{ inputSpan }} col-md-offset-{{ labelSpan }} col-md-{{ inputSpan }}">
                 {% if form.parent.vars.cancelUrl is defined and form.parent.vars.cancelUrl is not empty %}
-                    <a class="btn btn-default" href="{{ form.parent.vars.cancelUrl }}">{{ form.parent.vars.cancelLabel | default('Cancel') }}</a>
+                    <a class="btn btn-default" href="{{ form.parent.vars.cancelUrl }}">{{ form.parent.vars.cancelLabel | default('Abbrechen') }}</a>
                     &nbsp;
                 {% endif %}
 

--- a/Resources/views/_form/horizontal.html.twig
+++ b/Resources/views/_form/horizontal.html.twig
@@ -92,7 +92,7 @@
         <div class="form-group row">
             <div class="col-lg-offset-{{ labelSpan }} col-lg-{{ inputSpan }} col-md-offset-{{ labelSpan }} col-md-{{ inputSpan }}">
                 {% if form.parent.vars.cancelUrl is defined and form.parent.vars.cancelUrl is not empty %}
-                    <a class="btn btn-default" href="{{ form.parent.vars.cancelUrl }}">Abbrechen</a>
+                    <a class="btn btn-default" href="{{ form.parent.vars.cancelUrl }}">{{ form.parent.vars.cancelLabel | default('Cancel') }}</a>
                     &nbsp;
                 {% endif %}
 

--- a/Resources/views/_form/vertical.html.twig
+++ b/Resources/views/_form/vertical.html.twig
@@ -81,7 +81,7 @@
     {% spaceless %}
         <div class="form-group">
             {% if form.parent.vars.cancelUrl is defined and form.parent.vars.cancelUrl is not empty %}
-                <a class="btn btn-default" href="{{ form.parent.vars.cancelUrl }}">{{ form.parent.vars.cancelLabel | default('Cancel') }}</a>
+                <a class="btn btn-default" href="{{ form.parent.vars.cancelUrl }}">{{ form.parent.vars.cancelLabel | default('Abbrechen') }}</a>
                 &nbsp;
             {% endif %}
 

--- a/Resources/views/_form/vertical.html.twig
+++ b/Resources/views/_form/vertical.html.twig
@@ -81,7 +81,7 @@
     {% spaceless %}
         <div class="form-group">
             {% if form.parent.vars.cancelUrl is defined and form.parent.vars.cancelUrl is not empty %}
-                <a class="btn btn-default" href="{{ form.parent.vars.cancelUrl }}">Abbrechen</a>
+                <a class="btn btn-default" href="{{ form.parent.vars.cancelUrl }}">{{ form.parent.vars.cancelLabel | default('Cancel') }}</a>
                 &nbsp;
             {% endif %}
 


### PR DESCRIPTION
This change makes use of the newly added cancelLabel attribute for the generic forms, which is especially useful in an i18n environment where the cancel button can't be hardcoded.

**Note**: As it seems right now this bundle depends on Becklyn/BecklynRadBundle due to the FormTypeExtensions (adding support for `help`, `cancelUrl` and `cancelLabel`). In order to use/test this feature becklyn/becklynradbundle#3

**ToDo**: We also need to add a dependency to the composer.json or cleanup the cross references by refactoring the bundles.